### PR TITLE
feat: Add account multiplexer

### DIFF
--- a/client/multiplexers.go
+++ b/client/multiplexers.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+)
+
+func AccountMultiplex(meta schema.ClientMeta) []schema.ClientMeta {
+	var l = make([]schema.ClientMeta, 0)
+	client := meta.(*Client)
+	for _, account := range client.AccountConfigs {
+		l = append(l, client.withAccount(account))
+	}
+	return l
+}

--- a/client/resolvers.go
+++ b/client/resolvers.go
@@ -1,19 +1,12 @@
 package client
 
 import (
-	"crypto/sha1"
-	"encoding/base64"
-	"fmt"
+	"context"
+
+	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 )
 
-func CreateMetaID(accountName string, id int64) string {
-	hasher := sha1.New()
-	hasher.Write([]byte(fmt.Sprintf("%s-%d", accountName, id)))
-	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
-}
-
-func CreateMetaIDStr(accountName string, id string) string {
-	hasher := sha1.New()
-	hasher.Write([]byte(fmt.Sprintf("%s-%s", accountName, id)))
-	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+func ResolveAccountName(_ context.Context, meta schema.ClientMeta, r *schema.Resource, col schema.Column) error {
+	client := meta.(*Client)
+	return r.Set(col.Name, client.MultiPlexedAccount.Name)
 }

--- a/docs/tables/datadog_dashboard_lists.md
+++ b/docs/tables/datadog_dashboard_lists.md
@@ -4,6 +4,7 @@ DashboardList Your Datadog Dashboards.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |author_email|text|Email of the creator.|
 |author_handle|text|Handle of the creator.|
 |author_additional_properties|jsonb||

--- a/docs/tables/datadog_dashboards.md
+++ b/docs/tables/datadog_dashboards.md
@@ -4,6 +4,7 @@ Dashboard A dashboard is Datadog’s tool for visually tracking, analyzing, and 
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |author_handle|text|Identifier of the dashboard author.|
 |created_at|timestamp without time zone|Creation date of the dashboard.|
 |id|text|ID of the dashboard.|

--- a/docs/tables/datadog_downtimes.md
+++ b/docs/tables/datadog_downtimes.md
@@ -4,6 +4,7 @@ Downtime Downtiming gives you greater control over monitor notifications by allo
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |active|boolean|If a scheduled downtime currently exists.|
 |active_child|jsonb||
 |creator_id|integer|User ID of the downtime creator.|

--- a/docs/tables/datadog_hosts.md
+++ b/docs/tables/datadog_hosts.md
@@ -4,6 +4,7 @@ Host Object representing a host.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |aliases|text[]|Host aliases collected by Datadog.|
 |apps|text[]|The Datadog integrations reporting metrics for the host.|
 |aws_name|text|AWS name of your host.|

--- a/docs/tables/datadog_incidents.md
+++ b/docs/tables/datadog_incidents.md
@@ -4,6 +4,7 @@ IncidentResponseData Incident data from a response.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |attributes_created|timestamp without time zone|Timestamp when the incident was created.|
 |attributes_customer_impact_duration|bigint|Length of the incident's customer impact in seconds. Equals the difference between `customer_impact_start` and `customer_impact_end`.|
 |attributes_customer_impacted|boolean|A flag indicating whether the incident caused customer impact.|

--- a/docs/tables/datadog_monitors.md
+++ b/docs/tables/datadog_monitors.md
@@ -4,6 +4,7 @@ Monitor Object describing a monitor.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |created|timestamp without time zone|Timestamp of the monitor creation.|
 |creator_email|text|Email of the creator.|
 |creator_handle|text|Handle of the creator.|

--- a/docs/tables/datadog_notebooks.md
+++ b/docs/tables/datadog_notebooks.md
@@ -4,6 +4,7 @@ NotebooksResponseData The data for a notebook in get all response.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |attributes_author_created_at|timestamp without time zone|Creation time of the user.|
 |attributes_author_disabled|boolean|Whether the user is disabled.|
 |attributes_author_email|text|Email of the user.|

--- a/docs/tables/datadog_permissions.md
+++ b/docs/tables/datadog_permissions.md
@@ -4,6 +4,7 @@ Role Role object returned by the API.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |attributes_created_at|timestamp without time zone|Creation time of the role.|
 |attributes_modified_at|timestamp without time zone|Time of last role modification.|
 |attributes_name|text|The name of the role|

--- a/docs/tables/datadog_roles.md
+++ b/docs/tables/datadog_roles.md
@@ -4,6 +4,7 @@ Role Role object returned by the API.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |attributes_created_at|timestamp without time zone|Creation time of the role.|
 |attributes_modified_at|timestamp without time zone|Time of last role modification.|
 |attributes_name|text|The name of the role|

--- a/docs/tables/datadog_synthetics.md
+++ b/docs/tables/datadog_synthetics.md
@@ -4,6 +4,7 @@ SyntheticsTestDetails Object containing details about your Synthetic test.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |config|jsonb|Configuration object for a Synthetic test.|
 |creator_email|text|Email of the creator.|
 |creator_handle|text|Handle of the creator.|

--- a/docs/tables/datadog_users.md
+++ b/docs/tables/datadog_users.md
@@ -4,6 +4,7 @@ User User object returned by the API.
 ## Columns
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
+|account_name|text|The name of this datadog account from your config.|
 |attributes_created_at|timestamp without time zone|Creation time of the user.|
 |attributes_disabled|boolean|Whether the user is disabled.|
 |attributes_email|text|Email of the user.|

--- a/resources/services/dashboard_lists.go
+++ b/resources/services/dashboard_lists.go
@@ -14,9 +14,16 @@ func DashboardLists() *schema.Table {
 	return &schema.Table{
 		Name:        "datadog_dashboard_lists",
 		Description: "DashboardList Your Datadog Dashboards.",
+		Multiplex:   client.AccountMultiplex,
 		Resolver:    fetchDashboardLists,
 		Options:     schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{
+			{
+				Name:        "account_name",
+				Description: "The name of this datadog account from your config.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAccountName,
+			},
 			{
 				Name:        "author_email",
 				Description: "Email of the creator.",
@@ -86,8 +93,8 @@ func fetchDashboardLists(ctx context.Context, meta schema.ClientMeta, parent *sc
 	logger := c.Logger()
 	logger.Debug("in fetchHosts")
 	// TODO: multiplexing
-	apiClient := datadog.NewAPIClient(&c.Accounts[0].V1Config)
-	resp, _, err := apiClient.DashboardListsApi.ListDashboardLists(c.Accounts[0].V1Context)
+	apiClient := datadog.NewAPIClient(&c.MultiPlexedAccount.V1Config)
+	resp, _, err := apiClient.DashboardListsApi.ListDashboardLists(c.MultiPlexedAccount.V1Context)
 	if err != nil {
 		return diag.FromError(err, diag.ACCESS)
 	}

--- a/resources/services/dashboards.go
+++ b/resources/services/dashboards.go
@@ -14,9 +14,16 @@ func Dashboards() *schema.Table {
 	return &schema.Table{
 		Name:        "datadog_dashboards",
 		Description: "Dashboard A dashboard is Datadog’s tool for visually tracking, analyzing, and displaying key performance metrics, which enable you to monitor the health of your infrastructure.",
+		Multiplex:   client.AccountMultiplex,
 		Resolver:    fetchDashboards,
 		Options:     schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{
+			{
+				Name:        "account_name",
+				Description: "The name of this datadog account from your config.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAccountName,
+			},
 			{
 				Name:        "author_handle",
 				Description: "Identifier of the dashboard author.",
@@ -87,10 +94,10 @@ func Dashboards() *schema.Table {
 func fetchDashboards(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	logger := c.Logger()
-	logger.Debug("in fetchHosts")
+	logger.Debug("in fetchDashboards")
 	// TODO: multiplexing
-	apiClient := datadog.NewAPIClient(&c.Accounts[0].V1Config)
-	resp, r, err := apiClient.DashboardsApi.ListDashboards(c.Accounts[0].V1Context)
+	apiClient := datadog.NewAPIClient(&c.MultiPlexedAccount.V1Config)
+	resp, r, err := apiClient.DashboardsApi.ListDashboards(c.MultiPlexedAccount.V1Context)
 	logger.Debug(r.Status)
 	if err != nil {
 		return diag.FromError(err, diag.ACCESS)

--- a/resources/services/monitors.go
+++ b/resources/services/monitors.go
@@ -14,9 +14,16 @@ func Monitors() *schema.Table {
 	return &schema.Table{
 		Name:        "datadog_monitors",
 		Description: "Monitor Object describing a monitor.",
+		Multiplex:   client.AccountMultiplex,
 		Resolver:    fetchMonitors,
 		Options:     schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{
+			{
+				Name:        "account_name",
+				Description: "The name of this datadog account from your config.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAccountName,
+			},
 			{
 				Name:        "created",
 				Description: "Timestamp of the monitor creation.",
@@ -227,8 +234,8 @@ func fetchMonitors(ctx context.Context, meta schema.ClientMeta, parent *schema.R
 	logger := c.Logger()
 	logger.Debug("in fetchDatadogMonitors")
 	// TODO: multiplexing
-	apiClient := datadog.NewAPIClient(&c.Accounts[0].V1Config)
-	resp, r, err := apiClient.MonitorsApi.ListMonitors(c.Accounts[0].V1Context)
+	apiClient := datadog.NewAPIClient(&c.MultiPlexedAccount.V1Config)
+	resp, r, err := apiClient.MonitorsApi.ListMonitors(c.MultiPlexedAccount.V1Context)
 	logger.Debug(r.Status)
 	if err != nil {
 		return diag.FromError(err, diag.ACCESS)

--- a/resources/services/permissions.go
+++ b/resources/services/permissions.go
@@ -14,9 +14,16 @@ func Permissions() *schema.Table {
 	return &schema.Table{
 		Name:        "datadog_permissions",
 		Description: "Role Role object returned by the API.",
+		Multiplex:   client.AccountMultiplex,
 		Resolver:    fetchPermissions,
 		Options:     schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{
+			{
+				Name:        "account_name",
+				Description: "The name of this datadog account from your config.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAccountName,
+			},
 			{
 				Name:        "attributes_created_at",
 				Description: "Creation time of the role.",
@@ -83,9 +90,9 @@ func fetchPermissions(ctx context.Context, meta schema.ClientMeta, parent *schem
 	logger := c.Logger()
 	logger.Debug("in fetchHosts")
 	// TODO: multiplexing
-	apiClient := datadog.NewAPIClient(&c.Accounts[0].V2Config)
+	apiClient := datadog.NewAPIClient(&c.MultiPlexedAccount.V2Config)
 
-	resp, r, err := apiClient.RolesApi.ListPermissions(c.Accounts[0].V2Context)
+	resp, r, err := apiClient.RolesApi.ListPermissions(c.MultiPlexedAccount.V2Context)
 	logger.Debug(r.Status)
 	if err != nil {
 		return diag.FromError(err, diag.ACCESS)

--- a/resources/services/roles.go
+++ b/resources/services/roles.go
@@ -14,9 +14,16 @@ func Roles() *schema.Table {
 	return &schema.Table{
 		Name:        "datadog_roles",
 		Description: "Role Role object returned by the API.",
+		Multiplex:   client.AccountMultiplex,
 		Resolver:    fetchRoles,
 		Options:     schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{
+			{
+				Name:        "account_name",
+				Description: "The name of this datadog account from your config.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAccountName,
+			},
 			{
 				Name:        "attributes_created_at",
 				Description: "Creation time of the role.",
@@ -83,9 +90,9 @@ func fetchRoles(ctx context.Context, meta schema.ClientMeta, parent *schema.Reso
 	logger := c.Logger()
 	logger.Debug("in fetchHosts")
 	// TODO: multiplexing
-	apiClient := datadog.NewAPIClient(&c.Accounts[0].V2Config)
+	apiClient := datadog.NewAPIClient(&c.MultiPlexedAccount.V2Config)
 
-	resp, r, err := apiClient.RolesApi.ListRoles(c.Accounts[0].V2Context)
+	resp, r, err := apiClient.RolesApi.ListRoles(c.MultiPlexedAccount.V2Context)
 	logger.Debug(r.Status)
 	if err != nil {
 		return diag.FromError(err, diag.ACCESS)

--- a/resources/services/synthetics.go
+++ b/resources/services/synthetics.go
@@ -14,9 +14,16 @@ func Synthetics() *schema.Table {
 	return &schema.Table{
 		Name:        "datadog_synthetics",
 		Description: "SyntheticsTestDetails Object containing details about your Synthetic test.",
+		Multiplex:   client.AccountMultiplex,
 		Resolver:    fetchSynthetics,
 		Options:     schema.TableCreationOptions{PrimaryKeys: []string{"public_id"}},
 		Columns: []schema.Column{
+			{
+				Name:        "account_name",
+				Description: "The name of this datadog account from your config.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAccountName,
+			},
 			{
 				Name:        "config",
 				Description: "Configuration object for a Synthetic test.",
@@ -105,8 +112,8 @@ func fetchSynthetics(ctx context.Context, meta schema.ClientMeta, parent *schema
 	c := meta.(*client.Client)
 	logger := c.Logger()
 	// TODO: multiplexing
-	apiClient := datadog.NewAPIClient(&c.Accounts[0].V1Config)
-	resp, r, err := apiClient.SyntheticsApi.ListTests(c.Accounts[0].V1Context)
+	apiClient := datadog.NewAPIClient(&c.MultiPlexedAccount.V1Config)
+	resp, r, err := apiClient.SyntheticsApi.ListTests(c.MultiPlexedAccount.V1Context)
 	logger.Debug(r.Status)
 	if err != nil {
 		return diag.FromError(err, diag.ACCESS)


### PR DESCRIPTION
🎉 Thank you for making cq-provider-datadog awesome by submitting a PR 🎉

#### Summary

This adds an account multiplexer so that we can handle multiple datadog
accounts in a single fetch.

It adds a new column to each table, account_name, which has the datadog
account name that is defined in the config.

Resolves https://github.com/andrewthetechie/cq-provider-datadog/issues/7
---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] Ensure the status checks below are successful ✅
